### PR TITLE
Added support for nested buttons (folders) in the debug menu

### DIFF
--- a/Scripts/DebugMenu.cs
+++ b/Scripts/DebugMenu.cs
@@ -67,7 +67,8 @@ namespace DUCK.DebugMenu
 		[SerializeField]
 		private bool useNavigation;
 
-		private readonly Dictionary<string, Button> buttons = new Dictionary<string, Button>();
+		private DebugMenuItemNode rootNode;
+		private DebugMenuItemNode currentPageNode;
 
 		public event Action OnShow;
 		public event Action OnHide;
@@ -78,6 +79,8 @@ namespace DUCK.DebugMenu
 			instance = this;
 
 			rootObject.gameObject.SetActive(false);
+			rootNode = new DebugMenuItemNode();
+			currentPageNode = rootNode;
 
 			// When running tests you cannot use DontDestroyOnLoad in editor mode
 			if (Application.isPlaying)
@@ -116,6 +119,9 @@ namespace DUCK.DebugMenu
 		public void Show()
 		{
 			rootObject.SetActive(true);
+
+			currentPageNode = rootNode;
+			SetupPage(currentPageNode);
 
 			if (useNavigation)
 			{
@@ -175,79 +181,149 @@ namespace DUCK.DebugMenu
 		/// <summary>
 		/// Adds a new button to the debug menu that will invoke the specified action when clicked
 		/// </summary>
-		/// <param name="text">The text for the button, (this works like an id must be unique to all buttons)</param>
+		/// <param name="path">The path for the button, must be unique</param>
 		/// <param name="action">The action to invoke when clicked</param>
 		/// <param name="hideDebugMenuOnClick">A boolean used to control if the debug menu should hide when the button is clicked (defaults to true)</param>
-		public void AddButton(string text, Action action, bool hideDebugMenuOnClick = true)
+		public void AddButton(string path, Action action, bool hideDebugMenuOnClick = true)
 		{
-			if (string.IsNullOrEmpty(text)) throw new ArgumentNullException("text");
-			if (action == null) throw new ArgumentNullException("action");
+			if (string.IsNullOrEmpty(path)) throw new ArgumentNullException(nameof(path));
+			if (action == null) throw new ArgumentNullException(nameof(action));
 
-			if (!buttons.ContainsKey(text))
+			if (ButtonPathExists(path))
 			{
-				var actionButton = Instantiate(actionButtonTemplate);
-				actionButton.transform.SetParent(actionButtonTemplate.transform.parent, false);
-				actionButton.onClick.AddListener(() =>
-				{
-					action.Invoke();
-					if (hideDebugMenuOnClick)
-					{
-						Hide();
-					}
-				});
-				actionButton.GetComponentInChildren<Text>().text = text;
-				actionButton.gameObject.SetActive(true);
-				buttons.Add(text, actionButton);
+				throw new Exception($"Cannot add button at {path}. A button/folder already exists!");
 			}
-		}
 
-		/// <summary>
-		/// Updates a button in the debug menu.
-		/// </summary>
-		/// <param name="oldText">The text of the button to update</param>
-		/// <param name="newText">The new text of the button</param>
-		/// <param name="newAction">An optional replacement of the button onClick</param>
-		/// <param name="hideDebugMenuOnClick">Optional bool if the debug menu should hide when the button is clicked</param>
-		public void UpdateButton(string oldText, string newText, Action newAction = null, bool hideDebugMenuOnClick = true)
-		{
-			if (string.IsNullOrEmpty(oldText)) throw new ArgumentNullException("oldText");
-			if (string.IsNullOrEmpty(newText)) throw new ArgumentNullException("newText");
-
-			Button button;
-			if (!buttons.TryGetValue(oldText, out button)) return;
-
-			buttons.Remove(oldText);
-			button.GetComponentInChildren<Text>().text = newText;
-			buttons.Add(newText, button);
-
-			if (newAction != null)
+			// Add the button!
+			var parts = GetParts(path);
+			var currentNode = rootNode;
+			for (var i = 0; i < parts.Length; i++)
 			{
-				button.onClick.RemoveAllListeners();
-				button.onClick.AddListener(() =>
+				var isLast = i == parts.Length - 1;
+				var part = parts[i];
+				if (currentNode.ContainsChild(part))
 				{
-					newAction.Invoke();
-
-					if (hideDebugMenuOnClick)
-					{
-						Hide();
-					}
-				});
+					currentNode = currentNode.GetChild(part);
+				}
+				else
+				{
+					currentNode =
+						isLast ?
+						currentNode.AddButton(part, action, hideDebugMenuOnClick) :
+						currentNode.AddFolder(part);
+				}
 			}
 		}
 
 		/// <summary>
 		/// Removes a button from the debug menu.
 		/// </summary>
-		/// <param name="text">The text of the button to remove, (this works like an id must be unique to all buttons)</param>
-		public void RemoveButton(string text)
+		/// <param name="path">The path of of the button to remove</param>
+		public void RemoveButton(string path)
 		{
-			if (string.IsNullOrEmpty(text)) throw new ArgumentNullException("text");
+			if (string.IsNullOrEmpty(path)) throw new ArgumentNullException(nameof(path));
 
-			if (buttons.ContainsKey(text))
+			if (!ButtonPathExists(path))
 			{
-				Destroy(buttons[text].gameObject);
-				buttons.Remove(text);
+				throw new Exception($"Cannot remove the button {path}. It does not exist.");
+			}
+
+			var parts = GetParts(path);
+			var nodes = new List<DebugMenuItemNode>();
+			var currentNode = rootNode;
+			nodes.Add(currentNode);
+			foreach (var part in parts)
+			{
+				currentNode = currentNode.GetChild(part);
+				nodes.Add(currentNode);
+			}
+
+			for (var i = nodes.Count - 2; i >= 0; i--)
+			{
+				var parent = nodes[i];
+				var child = nodes[i + 1];
+				if (child.ChildCount == 0)
+				{
+					parent.RemoveChild(child.Name);
+				}
+			}
+		}
+
+		private string[] GetParts(string path)
+		{
+			return path.Split(new[] {'/', '\\'}, StringSplitOptions.RemoveEmptyEntries);
+		}
+
+		private bool ButtonPathExists(string path)
+		{
+			var parts = GetParts(path);
+			var currentNode = rootNode;
+			foreach (var part in parts)
+			{
+				if (currentNode.ContainsChild(part))
+				{
+					currentNode = currentNode.GetChild(part);
+				}
+				else
+				{
+					return false;
+				}
+			}
+
+			return true;
+		}
+
+		private void SetupPage(DebugMenuItemNode node)
+		{
+			currentPageNode = node;
+			foreach (Transform child in actionButtonTemplate.transform.parent)
+			{
+				if (child != actionButtonTemplate.transform)
+				{
+					Destroy(child.gameObject);
+				}
+			}
+
+			GameObject firstChild = null;
+
+			if (node.Parent != null)
+			{
+				var backButton = Instantiate(actionButtonTemplate, actionButtonTemplate.transform.parent, false);
+				backButton.GetComponentInChildren<Text>().text = "← Back";
+				backButton.onClick.AddListener(() => { SetupPage(node.Parent); });
+				backButton.gameObject.SetActive(true);
+
+				firstChild = backButton.gameObject;
+			}
+
+			foreach (var button in node.Children.Values)
+			{
+				var actionButton = Instantiate(actionButtonTemplate, actionButtonTemplate.transform.parent, false);
+				if (button.IsFolder)
+				{
+					actionButton.onClick.AddListener(() => { SetupPage(button); });
+				}
+				else
+				{
+					actionButton.onClick.AddListener(() =>
+					{
+						button.Action.Invoke();
+						if (button.HideOnClick) Hide();
+					});
+				}
+
+				var label = actionButton.GetComponentInChildren<Text>();
+				label.text = button.Name + (button.IsFolder ? " ▶" : "");
+				actionButton.gameObject.SetActive(true);
+
+				firstChild = (firstChild != null) ? firstChild : actionButton.gameObject;
+			}
+
+			if (useNavigation && firstChild != null)
+			{
+				EventSystem.current.SetSelectedGameObject(firstChild);
 			}
 		}
 	}
 }
+

--- a/Scripts/DebugMenuItemNode.cs
+++ b/Scripts/DebugMenuItemNode.cs
@@ -1,0 +1,73 @@
+using System;
+using System.Collections.Generic;
+
+namespace DUCK.DebugMenu
+{
+	public enum NodeType
+	{
+		Button,
+		Folder,
+	}
+
+	/// <summary>
+	/// A node used to build a hierarchy of debug menu items
+	/// </summary>
+	public class DebugMenuItemNode
+	{
+		public string Name { get; }
+		public NodeType Type { get; }
+		public bool IsFolder => Type == NodeType.Folder;
+		public bool IsButton => Type == NodeType.Button;
+		public Dictionary<string, DebugMenuItemNode> Children { get; private set; }
+		public int ChildCount => Children.Count;
+		public DebugMenuItemNode Parent { get; }
+		public Action Action { get; }
+		public bool HideOnClick { get; private set; }
+		public bool ContainsChild(string part) => Children.ContainsKey(part);
+		public DebugMenuItemNode GetChild(string part) => Children[part];
+
+		public DebugMenuItemNode(NodeType type = NodeType.Folder, string name = null, DebugMenuItemNode parent = null, Action action = null)
+		{
+			Type = type;
+			Children = new Dictionary<string, DebugMenuItemNode>();
+			Parent = parent;
+			Name = name;
+			Action = action;
+		}
+
+		public DebugMenuItemNode AddFolder(string name)
+		{
+			if (ContainsChild(name))
+			{
+				throw new Exception($"Cannot add with the name \"{name}\", it already exists");
+			}
+
+			var child = new DebugMenuItemNode(NodeType.Folder, name, this);
+			Children.Add(name, child);
+			return child;
+		}
+
+		public DebugMenuItemNode AddButton(string name, Action action, bool hideDebugMenuOnClick = true)
+		{
+			if (ContainsChild(name))
+			{
+				throw new Exception($"Cannot add with the name \"{name}\", it already exists");
+			}
+
+			var child = new DebugMenuItemNode(NodeType.Button, name, this, action);
+			child.HideOnClick = hideDebugMenuOnClick;
+			Children.Add(name, child);
+			return child;
+		}
+
+		public void RemoveChild(string childName)
+		{
+			if (!ContainsChild(childName))
+			{
+				throw new Exception($"Cannot remove child {childName}, it does not exist");
+			}
+
+			Children.Remove(childName);
+		}
+	}
+}

--- a/Scripts/DebugMenuItemNode.cs.meta
+++ b/Scripts/DebugMenuItemNode.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 36377802acd84ab88dac70436218fbb8
+timeCreated: 1549276440

--- a/Scripts/Navigation/NavigableScrollElement.cs
+++ b/Scripts/Navigation/NavigableScrollElement.cs
@@ -35,6 +35,8 @@ namespace DUCK.DebugMenu.Navigation
 
 		public void OnSelect(BaseEventData eventData)
 		{
+			if (rootCanvasTransform == null) return;
+
 			// get world space corners of our own rect
 			var corners = new Vector3[4];
 			((RectTransform) transform).GetWorldCorners(corners);


### PR DESCRIPTION
Addresss #7 

Similar to the unity `[MenuItem]` attributes API.

The following code:
```
var debugMenu = DebugMenu.Instance;
debugMenu.AddButton("ButtonA", () => Debug.Log("A"));
debugMenu.AddButton("FolderA/ButtonB", () => Debug.Log("B"));
debugMenu.AddButton("FolderA/ButtonC", () => Debug.Log("C"));
debugMenu.AddButton("FolderA/ButtonD", () => Debug.Log("D"));
debugMenu.AddButton("FolderA/FolderB/ButtonE", () => Debug.Log("E"));
debugMenu.AddButton("FolderA/FolderC/ButtonF", () => Debug.Log("F"));
debugMenu.AddButton("FolderA/FolderD/ButtonG", () => Debug.Log("G"));
```

Produces the following image: 

![image](https://user-images.githubusercontent.com/5612566/52208901-18e08800-287a-11e9-8df7-957fe45bc4e7.png)

![image](https://user-images.githubusercontent.com/5612566/52208905-1bdb7880-287a-11e9-9f2d-762fbd276446.png)

# API Removal
The `UpdateButton` API has been removed. It was basically useless, it's just remove and add all in one. The benefit of before was that it didn't need to instantiate a new button, which is more efficient and also it kept it in the same place/order. I figured that efficiency is not important for a debug menu (and now we are recreating the buttons whenever we change page). Also now if you change the path then order is not important. I think the function was pretty pointless anyway, and there would be less need for it now that you can organise your debug functions using folders.
