### PR TITLE
Clear button interactable state no longer changes

### DIFF
--- a/Scripts/Logger/DebugLogPage.cs
+++ b/Scripts/Logger/DebugLogPage.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections;
+﻿using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -67,8 +66,6 @@ namespace DUCK.DebugMenu.Logger
 		private readonly Color oddBackgroundColor = new Color(0.95f, 0.95f, 0.95f);
 		private readonly List<LogEntryElement> allLogs = new List<LogEntryElement>();
 		private Dictionary<LogType, LogTypeData> logTypeDatas;
-
-		public event Action OnLogsCleared;
 
 		private void Awake()
 		{

--- a/Scripts/Logger/DebugLogPage.cs
+++ b/Scripts/Logger/DebugLogPage.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections;
+﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -67,12 +68,13 @@ namespace DUCK.DebugMenu.Logger
 		private readonly List<LogEntryElement> allLogs = new List<LogEntryElement>();
 		private Dictionary<LogType, LogTypeData> logTypeDatas;
 
+		public event Action OnLogsCleared;
+
 		private void Awake()
 		{
 			entryPrefab.gameObject.SetActive(false);
 			scrollRect.gameObject.SetActive(false);
 			stackTraceContainer.gameObject.SetActive(false);
-			clearButton.interactable = false;
 			clearButton.onClick.AddListener(Clear);
 
 			var errorLogData = new LogTypeData(toggleErrorButton, errorIcon);
@@ -144,7 +146,6 @@ namespace DUCK.DebugMenu.Logger
 
 			allLogs.Clear();
 
-			clearButton.interactable = false;
 			scrollRect.gameObject.SetActive(false);
 		}
 
@@ -154,8 +155,6 @@ namespace DUCK.DebugMenu.Logger
 			{
 				scrollRect.gameObject.SetActive(true);
 			}
-
-			clearButton.interactable = true;
 
 			var logTypeData = logTypeDatas[logType];
 			var newLogEntry = Instantiate(entryPrefab, container, false);


### PR DESCRIPTION
Disabling interactivity on the button after it's pressed breaks the UI if you use navigation. That was the currently selected game object and now it's interactable you cannot move off that button to select another button. I could have added a navigation check and highlight a different button, but rather than increased complexity we can just let the button always be clickable. It breaks nothing and it's not really a big UX sacrifice. Unity clear logs button is still clickable when the console has been cleared